### PR TITLE
fix: adds 'types' to the list of export conditions so the resolver knows to find the types exports condition in module only + type only modules

### DIFF
--- a/.dependency-cruiser.js
+++ b/.dependency-cruiser.js
@@ -153,7 +153,7 @@ module.exports = {
         If you have a 'conditionNames' attribute in your webpack config, that one will
         have precedence over the one specified here.
       */
-      conditionNames: ["import", "require", "node", "default"],
+      conditionNames: ["import", "require", "node", "default", "types"],
       /*
          The extensions, by default are the same as the ones dependency-cruiser
          can access (run `npx depcruise --info` to see which ones that are in


### PR DESCRIPTION
See https://github.com/sverweij/dependency-cruiser/issues/900 for an explanation